### PR TITLE
feat(env)+docs: ChronoViperWalk-v0 + README — AMD ROCm, Ray, Gymnasium

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,90 @@ This repository consists of a set of gymnasium "environments" which are essentia
 
 The `off_road_gator` example has been updated to use the **Chrono main repository**, which can be found at [https://github.com/projectchrono/chrono](https://github.com/projectchrono/chrono).
 
+## ChronoViperWalk-v0 (Chrono 10 + Gymnasium)
+
+This repository registers **`ChronoViperWalk-v0`**: a **headless** Gymnasium environment built on **Chrono 10** PyChrono bindings (`ChFramed`, `ChVector3d`, `SetGravitationalAcceleration`, NSC + **Bullet** collision) and **`pychrono.robot.Viper`**. Observation and action shapes are **18** and **12** respectively (the same *sizes* as the older `quadruped_walk` env for tooling compatibility). The reward is a simple **forward Δx** signal — it is **not** a drop-in replacement for every published quadruped benchmark.
+
+**Prerequisites:** PyChrono with the **robot** module, `gymnasium`, `numpy`, and `CHRONO_DATA_DIR` pointing at a Chrono data tree (see below).
+
+**Smoke test (from the repository root, after setting `PYTHONPATH`):**
+
+```bash
+export CHRONO_DATA_DIR="/path/to/chrono/data/"
+export PYTHONPATH="/path/to/gym-chrono:$PYTHONPATH"
+python3 gym_chrono/test/smoke_viper_walk.py
+```
+
+**One-liner check:**
+
+```bash
+python3 - <<'PY'
+import gymnasium as gym
+import gym_chrono  # registers envs
+env = gym.make("ChronoViperWalk-v0", render_mode=None)
+obs, _ = env.reset(seed=0)
+obs2, r, term, trunc, _ = env.step(env.action_space.sample())
+env.close()
+print("obs", obs.shape, "->", obs2.shape, "r", r, "done", term or trunc)
+PY
+```
+
+## Version matrix (reference)
+
+Exact pins depend on your Chrono build and training stack. Use this table as a **documentation anchor**; adjust cells to match what you validate in CI.
+
+| Component | Example pin / note |
+|-----------|-------------------|
+| **Project Chrono** / PyChrono | Build from [projectchrono/chrono](https://github.com/projectchrono/chrono) `main` (or your supported tag) with **Python** and **robot** enabled for `ChronoViperWalk-v0`. |
+| **Python** | 3.10–3.12 (match your PyChrono wheel or build). |
+| **gymnasium** | ≥ 0.29 (tested with modern `gym.make` API). |
+| **numpy** | Match PyChrono’s supported NumPy line (many Chrono Python builds expect **1.24.x**). |
+| **rsl-rl-lib** (optional) | If you use RSL-RL, align the **major** line with your YAML / config schema (2.x vs 5.x differ). |
+| **PyTorch** (optional learner) | CUDA build **or** ROCm wheel from [PyTorch ROCm install](https://pytorch.org/get-started/locally/) — must match your driver stack. |
+
+## Ray + PyTorch ROCm (CPU Chrono workers, GPU learner)
+
+When you run **many CPU-only Chrono** simulations under **Ray** while a **PyTorch ROCm** policy trains on AMD GPUs, use two patterns:
+
+1. **Set Ray’s ROCm-safe environment variables before the first `import ray`** (Ray ≥ 2.45 on PyTorch ROCm):
+
+```python
+import os
+
+os.environ.setdefault("RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES", "1")
+os.environ.setdefault("RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES", "1")
+
+import ray  # noqa: E402
+```
+
+The [ChronoRay](https://github.com/uwsbel/chrono-ray) package documents the same bootstrap under `docs/AMD_ROCM.md` and exposes `prepare_rocm_ray_env()` if you already depend on that project.
+
+2. **Hide GPUs inside Ray workers** that only run CPU physics, so they do not attach to HIP devices:
+
+```python
+_CHRONO_CPU_ENV = {
+    "env_vars": {
+        "HIP_VISIBLE_DEVICES": "-1",
+        "ROCR_VISIBLE_DEVICES": "-1",
+    }
+}
+
+
+@ray.remote(num_cpus=1, runtime_env=_CHRONO_CPU_ENV)
+class ChronoSimActor:
+    def __init__(self, seed: int):
+        import gymnasium as gym
+        import gym_chrono  # noqa: F401
+
+        self._env = gym.make("ChronoViperWalk-v0", render_mode=None)
+        self._env.reset(seed=seed)
+
+    def step(self, action):
+        return self._env.step(action)
+```
+
+**AMD GPU selection** for the **learner** process should use **`ROCR_VISIBLE_DEVICES`**, not `CUDA_VISIBLE_DEVICES`. When starting Ray manually, pass **`ray start --num-gpus=N`** (with `N` matching visible devices); otherwise Ray may schedule **zero** GPUs even when hardware is present.
+
 ## Downloading data files
 Before you begin the installation process, you will need to download the `data` folder containing the simulation assets and place it in the right place:
 1) Download the data files [here](https://drive.google.com/drive/folders/1u4nwAlpPXtgkSJeBLlSM9B_utEoUIY41?usp=drive_link), unzip if necessary, you should obtain a folder named `data`.
@@ -35,7 +119,7 @@ For Windows users:
 ## Installing dependencies
 ### Installing pychrono
 1) First you need to install pychrono from source. The Chrono source that needs to be cloned is linked [here](https://github.com/zzhou292/chrono/tree/feature/robot_model). Please use the feature/robot_model branch. We use this fork with this branch because it contains all the latest robot models that are not currently available in Chrono main.
-2) Once you have the source cloned, build pychrono from source using instructions found [here]([url](https://api.projectchrono.org/module_python_installation.html)https://api.projectchrono.org/module_python_installation.html). Enable modules Chrono::Sensor, Chrono::Irrlicht, Chrono::SynChrono, Chrono::Vehicle, Chrono::Python, Chrono::OPENMP and Chrono::Parsers. For each of these modules, please look at the official Chrono documentation.
+2) Once you have the source cloned, build pychrono from source using the official [Python module installation](https://api.projectchrono.org/module_python_installation.html) guide. Enable modules Chrono::Sensor, Chrono::Irrlicht, Chrono::SynChrono, Chrono::Vehicle, Chrono::Python, Chrono::OPENMP and Chrono::Parsers. For each of these modules, please look at the official Chrono documentation.
 3) Make sure you add the appropriate numpy include directory (see linked instructions above)
 4) If you are not doing a system wide install of pychrono, make sure you add to PYTHONPATH the path to the installed python libraries (see linked instructions above)
 ### Installing gymnasium

--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ class ChronoSimActor:
 
 **AMD GPU selection** for the **learner** process should use **`ROCR_VISIBLE_DEVICES`**, not `CUDA_VISIBLE_DEVICES`. When starting Ray manually, pass **`ray start --num-gpus=N`** (with `N` matching visible devices); otherwise Ray may schedule **zero** GPUs even when hardware is present.
 
+### Reviewer reproduction (generic AMD Linux: CPUs + Instinct)
+
+1. Install **ROCm** and build **PyChrono** with **Python + robot**; set **`CHRONO_DATA_DIR`** and prepend the Chrono Python path to **`PYTHONPATH`** (see [Chrono Python install](https://api.projectchrono.org/module_python_installation.html)).
+2. Clone this branch, prepend **`PYTHONPATH=$PWD`**, create a venv, `pip install gymnasium numpy`, run **`python3 gym_chrono/test/smoke_viper_walk.py`**.
+3. For **Ray + Instinct**: export **`ROCR_VISIBLE_DEVICES`**, set **`RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES`** and **`RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES`** before `import ray`, run **`ray start --head --num-gpus=N`**, then run **`python3 playground/reviewer_ray_chrono_smoke.py`** (minimal two-actor smoke; requires `ray` installed).
+
+Full step-by-step reproduction (shell + inline Python) is in the **“Reviewer reproduction”** section of **[PR #19](https://github.com/projectchrono/gym-chrono/pull/19)** on GitHub.
+
 ## Downloading data files
 Before you begin the installation process, you will need to download the `data` folder containing the simulation assets and place it in the right place:
 1) Download the data files [here](https://drive.google.com/drive/folders/1u4nwAlpPXtgkSJeBLlSM9B_utEoUIY41?usp=drive_link), unzip if necessary, you should obtain a folder named `data`.

--- a/gym_chrono/__init__.py
+++ b/gym_chrono/__init__.py
@@ -1,8 +1,15 @@
 import logging
+
 import gymnasium as gym
 from gymnasium.envs.registration import register
 
+register(
+    id="art_wpts-v0",
+    entry_point="gym_chrono.envs:art_wpts",
+)  # legacy registration (may be unused — preserved for compatibility)
 
 register(
-    id='art_wpts-v0',
-    entry_point='gym_chrono.envs:art_wpts')  # NAme of the CLASS after the colon
+    id="ChronoViperWalk-v0",
+    entry_point="gym_chrono.envs.legged.viper_walk:ChronoViperWalkEnv",
+    max_episode_steps=100_000,
+)

--- a/gym_chrono/envs/__init__.py
+++ b/gym_chrono/envs/__init__.py
@@ -1,1 +1,7 @@
-from gym_chrono.envs.ChronoBase import ChronoBaseEnv
+"""gym_chrono.envs — environment implementations.
+
+Submodules import :class:`~gym_chrono.envs.ChronoBase.ChronoBaseEnv` directly
+from ``gym_chrono.envs.ChronoBase``; this package ``__init__`` stays empty so
+minimal envs (e.g. Chrono 10 Viper walk) can load without pulling optional
+Chrono modules through unrelated imports.
+"""

--- a/gym_chrono/envs/legged/__init__.py
+++ b/gym_chrono/envs/legged/__init__.py
@@ -1,0 +1,1 @@
+"""Legged / rover Gymnasium environments (submodules: ``viper_walk``, ``quadruped_walk``, …)."""

--- a/gym_chrono/envs/legged/viper_walk.py
+++ b/gym_chrono/envs/legged/viper_walk.py
@@ -1,0 +1,144 @@
+# =============================================================================
+# Chrono 10 + Gymnasium: Viper rover walk (scaling surrogate).
+# Not the Chrono-Gymnasium paper R^45 velocity-tracking task; obs/act dims
+# match legacy quadruped_walk-style stacks (18 / 12) for tooling compatibility.
+# =============================================================================
+from __future__ import annotations
+
+import math
+import os
+from pathlib import Path
+
+import gymnasium as gym
+import numpy as np
+import pychrono as chrono
+import pychrono.robot as robot
+
+
+def _set_chrono_data_path() -> None:
+    """Set Chrono data directory without importing optional Chrono modules."""
+    data = os.environ.get("CHRONO_DATA_DIR")
+    if not data:
+        conda = os.environ.get("CONDA_PREFIX")
+        if conda:
+            cand = os.path.join(conda, "share", "chrono", "data", "")
+            if os.path.isdir(cand):
+                data = cand
+    if not data:
+        # Repo layout: optional gym_chrono/envs/data per upstream README
+        envs_dir = Path(__file__).resolve().parents[1]
+        cand = envs_dir / "data"
+        if cand.is_dir():
+            data = str(cand) + os.sep
+    if data:
+        chrono.SetChronoDataPath(data)
+
+
+class ChronoViperWalkEnv(gym.Env):
+    """Viper rover forward-drive on NSC + Bullet; headless (render_mode=None)."""
+
+    metadata = {"render_modes": [None]}
+
+    def __init__(self, render_mode=None):
+        super().__init__()
+        self.action_space = gym.spaces.Box(
+            low=-3.0, high=3.0, shape=(12,), dtype=np.float64
+        )
+        self.observation_space = gym.spaces.Box(
+            low=-30.0, high=30.0, shape=(18,), dtype=np.float64
+        )
+        self.render_mode = render_mode
+
+        self._step_size = 5e-4
+        self._control_frequency = 20
+        self._steps_per_control = max(
+            1, round(1.0 / (self._step_size * self._control_frequency))
+        )
+        self._max_time = 50.0
+
+        self.system: chrono.ChSystemNSC | None = None
+        self.rover: robot.Viper | None = None
+        self.driver: robot.ViperDCMotorControl | None = None
+        self._prev_x = 0.0
+
+    def reset(self, seed=None, options=None):
+        super().reset(seed=seed)
+        self._prev_x = 0.0
+
+        _set_chrono_data_path()
+
+        self.system = chrono.ChSystemNSC()
+        self.system.SetGravitationalAcceleration(chrono.ChVector3d(0, 0, -9.81))
+        self.system.SetCollisionSystemType(chrono.ChCollisionSystem.Type_BULLET)
+        chrono.ChCollisionModel.SetDefaultSuggestedEnvelope(0.001)
+        chrono.ChCollisionModel.SetDefaultSuggestedMargin(0.001)
+
+        ground_mat = chrono.ChContactMaterialNSC()
+        ground = chrono.ChBodyEasyBox(20, 20, 0.1, 1000, True, True, ground_mat)
+        ground.SetPos(chrono.ChVector3d(0, 0, -0.05))
+        ground.SetFixed(True)
+        try:
+            if ground.GetVisualShape(0) is not None:
+                ground.GetVisualShape(0).SetTexture(
+                    chrono.GetChronoDataFile("textures/concrete.jpg")
+                )
+        except Exception:
+            pass
+        self.system.Add(ground)
+
+        wheel_mat = chrono.ChContactMaterialNSC()
+        self.driver = robot.ViperDCMotorControl()
+        self.rover = robot.Viper(self.system, robot.ViperWheelType_SimpleWheel)
+        self.rover.SetWheelContactMaterial(wheel_mat)
+        self.rover.SetDriver(self.driver)
+        self.rover.Initialize(
+            chrono.ChFramed(
+                chrono.ChVector3d(0, 0, 0.4), chrono.ChQuaterniond(1, 0, 0, 0)
+            )
+        )
+
+        return self._get_obs(), {}
+
+    def step(self, action):
+        assert self.system is not None and self.rover is not None and self.driver is not None
+
+        torques = [float(np.clip(action[i], -3, 3)) * 5.0 for i in range(4)]
+        steer = float(np.clip(action[4], -1, 1)) * (math.pi / 12)
+        wheel_ids = (robot.FL, robot.FR, robot.RL, robot.RR)
+        for wid, tq in zip(wheel_ids, torques):
+            self.driver.SetMotorStallTorque(tq, wid)
+        self.driver.SetSteering(steer)
+
+        for _ in range(self._steps_per_control):
+            self.rover.Update()
+            self.system.DoStepDynamics(self._step_size)
+
+        obs = self._get_obs()
+        reward = self._get_reward()
+        terminated = self.system.GetChTime() >= self._max_time
+        truncated = False
+        return obs, reward, terminated, truncated, {}
+
+    def _get_obs(self) -> np.ndarray:
+        assert self.rover is not None
+        pos = self.rover.GetChassisPos()
+        vel = self.rover.GetChassisVel()
+        rot = self.rover.GetChassisRot()
+        obs = np.zeros(18, dtype=np.float64)
+        obs[0:3] = [pos.x, pos.y, pos.z]
+        obs[3:6] = [vel.x, vel.y, vel.z]
+        obs[6:10] = [rot.e0, rot.e1, rot.e2, rot.e3]
+        obs[10:14] = [
+            self.rover.GetWheelLinVel(robot.FL).x,
+            self.rover.GetWheelLinVel(robot.FR).x,
+            self.rover.GetWheelLinVel(robot.RL).x,
+            self.rover.GetWheelLinVel(robot.RR).x,
+        ]
+        return obs
+
+    def _get_reward(self) -> float:
+        assert self.rover is not None
+        x = self.rover.GetChassisPos().x
+        reward = x - self._prev_x
+        self._prev_x = x
+        return float(reward)

--- a/gym_chrono/test/smoke_viper_walk.py
+++ b/gym_chrono/test/smoke_viper_walk.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Smoke test for ChronoViperWalk-v0 (WS3a). Run from repo root:
+
+  export CHRONO_DATA_DIR=/path/to/chrono/data/
+  export PYTHONPATH=/path/to/gym-chrono-ws3
+  python3 gym_chrono/test/smoke_viper_walk.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main() -> int:
+    root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    if root not in sys.path:
+        sys.path.insert(0, root)
+
+    import gymnasium as gym
+
+    import gym_chrono  # noqa: F401 — registers envs
+
+    env = gym.make("ChronoViperWalk-v0", render_mode=None)
+    obs, _ = env.reset(seed=0)
+    a = env.action_space.sample()
+    obs2, r, term, trunc, _ = env.step(a)
+    env.close()
+    print("ok", obs.shape, obs2.shape, r, term, trunc)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/playground/reviewer_ray_chrono_smoke.py
+++ b/playground/reviewer_ray_chrono_smoke.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""
+Minimal Ray + ChronoViperWalk smoke for AMD Linux (Instinct + ROCm).
+
+Prerequisites:
+  - CHRONO_DATA_DIR, PYTHONPATH includes gym-chrono and PyChrono build
+  - ray start --head --num-gpus=N (optional if you only test CPU actors)
+  - RAY_EXPERIMENTAL_NOSET_* set before import ray (this script does that)
+
+Run:
+  python3 playground/reviewer_ray_chrono_smoke.py
+"""
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES", "1")
+os.environ.setdefault("RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES", "1")
+
+import ray
+
+_CHRONO_CPU = {
+    "env_vars": {
+        "HIP_VISIBLE_DEVICES": "-1",
+        "ROCR_VISIBLE_DEVICES": "-1",
+    }
+}
+
+
+@ray.remote(num_cpus=1, runtime_env=_CHRONO_CPU)
+class ViperActor:
+    def __init__(self, seed: int) -> None:
+        import gymnasium as gym
+
+        import gym_chrono  # noqa: F401 — registration
+
+        self._env = gym.make("ChronoViperWalk-v0", render_mode=None)
+        self._env.reset(seed=seed)
+
+    def step(self) -> float:
+        a = self._env.action_space.sample()
+        _obs, r, _term, _trunc, _info = self._env.step(a)
+        return float(r)
+
+
+def main() -> None:
+    if not os.environ.get("CHRONO_DATA_DIR"):
+        raise SystemExit("Set CHRONO_DATA_DIR to your Chrono data directory.")
+    ray.init()
+    actors = [ViperActor.remote(i) for i in range(2)]
+    rewards = ray.get([a.step.remote() for a in actors])
+    print("rewards", rewards)
+    ray.shutdown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

> **PR title (GitHub):** `feat(env)+docs: ChronoViperWalk-v0 + README — AMD ROCm, Ray, Gymnasium`

This pull request **combines** (1) a new **Chrono 10–native** Gymnasium environment and (2) **README** guidance for **version pinning**, optional **PyTorch ROCm + Ray** layouts, and **reviewer-runnable** smoke commands.

### A — New environment: `ChronoViperWalk-v0`

- Headless **`gym.Env`** using **NSC + Bullet** and **`pychrono.robot.Viper`** with Chrono 10 bindings (`ChFramed`, `ChVector3d`, `SetGravitationalAcceleration`, `system.Add`, …).
- Registered in `gym_chrono/__init__.py` as **`ChronoViperWalk-v0`** (`max_episode_steps=100_000`).
- **Observation** `Box(18,)`, **action** `Box(12,)` — same *tensor shapes* as the legacy `quadruped_walk` env for reuse of common policy widths; **reward is not identical** to every published quadruped benchmark (simple forward Δx).
- **`gym_chrono/test/smoke_viper_walk.py`** — minimal `reset` + `step` for CI or manual validation.

### B — README: version matrix + ROCm + Ray

- New sections: **ChronoViperWalk quick start**, **version matrix** (Chrono / Python / gymnasium / numpy / optional rsl-rl-lib / PyTorch), **Ray + PyTorch ROCm** (bootstrap env vars before `import ray`, `runtime_env` for CPU-only sim actors, `ROCR_VISIBLE_DEVICES`, `ray start --num-gpus`).
- Fixed a broken PyChrono install hyperlink in the existing README.

### C — Import hygiene

- **`gym_chrono/envs/__init__.py`** no longer eagerly imports `ChronoBase` (submodules already import from `gym_chrono.envs.ChronoBase` directly).
- **`gym_chrono/envs/legged/__init__.py`** avoids importing `viper_walk` at package import time so `gym.make("ChronoViperWalk-v0")` does not pull unrelated env code first.

---

## What changed (files)

| File | Change |
|------|--------|
| `gym_chrono/envs/legged/viper_walk.py` | **New** — `ChronoViperWalkEnv` + local `_set_chrono_data_path()` (no hard dependency on `pychrono.vehicle` / `pychrono.sensor` via `utils.py` for this env). |
| `gym_chrono/__init__.py` | Register **`ChronoViperWalk-v0`**; normalize quoting for legacy `art_wpts-v0` entry. |
| `gym_chrono/envs/__init__.py` | **Lazy** package docstring (no eager `ChronoBase` import). |
| `gym_chrono/envs/legged/__init__.py` | **Lazy** legged package marker. |
| `gym_chrono/test/smoke_viper_walk.py` | **New** — smoke harness. |
| `README.md` | **Extended** — ChronoViperWalk section, version matrix, ROCm + Ray patterns, runnable shell/Python examples; **link fix** for PyChrono install docs. |

---

## Code snippets (for reviewers)

### Gymnasium registration

```python
from gymnasium.envs.registration import register

register(
    id="ChronoViperWalk-v0",
    entry_point="gym_chrono.envs.legged.viper_walk:ChronoViperWalkEnv",
    max_episode_steps=100_000,
)
```

### Ray bootstrap before `import ray` (PyTorch ROCm + Ray ≥ 2.45)

```python
import os

os.environ.setdefault("RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES", "1")
os.environ.setdefault("RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES", "1")

import ray  # noqa: E402
```

### CPU-only Chrono inside a Ray actor (optional pattern)

```python
_CHRONO_CPU_ENV = {
    "env_vars": {
        "HIP_VISIBLE_DEVICES": "-1",
        "ROCR_VISIBLE_DEVICES": "-1",
    }
}


@ray.remote(num_cpus=1, runtime_env=_CHRONO_CPU_ENV)
class ChronoSimActor:
    def __init__(self, seed: int):
        import gymnasium as gym
        import gym_chrono  # noqa: F401

        self._env = gym.make("ChronoViperWalk-v0", render_mode=None)
        self._env.reset(seed=seed)

    def step(self, action):
        return self._env.step(action)
```

---

## Running examples (copy-paste)

**1) Environment smoke (requires PyChrono + `CHRONO_DATA_DIR`):**

```bash
export CHRONO_DATA_DIR="/path/to/chrono/data/"
export PYTHONPATH="/path/to/gym-chrono:$PYTHONPATH"
python3 gym_chrono/test/smoke_viper_walk.py
```

**2) Inline `gym.make` check:**

```bash
python3 - <<'PY'
import gymnasium as gym
import gym_chrono  # noqa: F401 — registration side effect
env = gym.make("ChronoViperWalk-v0", render_mode=None)
obs, _ = env.reset(seed=0)
obs2, r, term, trunc, _ = env.step(env.action_space.sample())
env.close()
print("obs", obs.shape, "->", obs2.shape, "r", r, "done", term or trunc)
PY
```

**3) Optional syntax-only check (no PyChrono import of the env at runtime):**

```bash
python3 -m py_compile gym_chrono/envs/legged/viper_walk.py gym_chrono/test/smoke_viper_walk.py
```

---

## Test plan (for reviewers)

### Environment (`ChronoViperWalk-v0`)

- [ ] Install or build **PyChrono** with **`pychrono.robot`** on `PYTHONPATH`.
- [ ] Set **`CHRONO_DATA_DIR`** to a valid Chrono data directory (textures optional; ground texture load is best-effort).
- [ ] `pip install gymnasium numpy` in a clean venv.
- [ ] Run **`python3 gym_chrono/test/smoke_viper_walk.py`** — expect `ok` and printed shapes `(18,)`.
- [ ] Run the **inline `gym.make`** example above — no exceptions through `reset` + one `step`.

### README / documentation

- [ ] Follow the **ChronoViperWalk** section from a fresh clone with only `PYTHONPATH` set (no undocumented steps).
- [ ] Confirm the **version matrix** rows match what you intend to support (edit table if your CI uses different pins).
- [ ] Skim **Ray + ROCm** section: examples use **`ROCR_VISIBLE_DEVICES`** for AMD GPU visibility (not `CUDA_VISIBLE_DEVICES` as the primary selector) and mention **`ray start --num-gpus=N`**.

### Regression / import hygiene

- [ ] `python3 -c "import gym_chrono"` then `import gymnasium as gym; gym.make('ChronoViperWalk-v0')` on a host **with** PyChrono.
- [ ] Confirm no new **mandatory** dependency on `pychrono.sensor` / `pychrono.vehicle` was introduced for **`ChronoViperWalk-v0`** specifically.

---

## AMD-specific vs portable

| Topic | Scope |
|-------|--------|
| **`ChronoViperWalkEnv` physics** | **Portable CPU** (NSC + Bullet + Viper). Not a HIP kernel port. |
| **`ROCR_VISIBLE_DEVICES`, `HIP_VISIBLE_DEVICES` in Ray `runtime_env`** | **AMD ROCm + Ray** operational guidance for separating **CPU Chrono** workers from **GPU** learners. |
| **`RAY_EXPERIMENTAL_NOSET_*` before `import ray`** | **Ray on PyTorch ROCm** (≥ 2.45) — relevant to AMD ROCm stacks; harmless on many other stacks when set via `setdefault`. |
| **`ray start --num-gpus=N`** | **Ray scheduling** — not vendor-specific, but commonly hits ROCm + MI-class multi-GPU nodes. |

---

## Reviewer reproduction (generic AMD Linux: CPUs + Instinct GPUs)

These steps assume a **64-bit Linux** host with **AMD ROCm** installed for **Instinct** GPUs (e.g. MI200 / MI300 class), **Python 3.10+**, and permission to use the GPU stack. They intentionally avoid **site-specific** paths, schedulers, or cluster-only configuration.

### 0) Sanity checks (optional)

```bash
# ROCm user-land visible
rocm-smi --showproductname || true

# HIP compiler available (build hosts only)
hipconfig --version || true
```

### 1) Build or install **PyChrono** (Chrono 10 + `robot` module)

Point **`CHRONO_DATA_DIR`** at a checkout of Chrono’s **`data/`** tree (textures, meshes). Build PyChrono following the official [Python module installation](https://api.projectchrono.org/module_python_installation.html) guide. Enable at least **Python** and **robot** for `ChronoViperWalk-v0` (other modules optional for this env).

Set:

```bash
export CHRONO_DATA_DIR="/absolute/path/to/chrono/data/"   # trailing slash OK
export PYTHONPATH="/absolute/path/to/chrono/build/bin:${PYTHONPATH:-}"
```

(Adjust `build/bin` to wherever `pychrono` was installed for your build.)

### 2) Check out **this PR branch** of `gym-chrono`

```bash
export GYM_CHRONO_ROOT="${GYM_CHRONO_ROOT:-$HOME/src/gym-chrono}"
git clone https://github.com/amd-pratmish/gym-chrono.git "$GYM_CHRONO_ROOT"
cd "$GYM_CHRONO_ROOT"
git fetch origin feat/chrono10-viper-walk-env
git checkout feat/chrono10-viper-walk-env
export PYTHONPATH="$GYM_CHRONO_ROOT:${PYTHONPATH:-}"
```

(You can instead merge the PR locally or add the fork as `git remote add`.)

### 3) Python venv and **CPU-only** smoke (no Ray, no GPU required for physics)

```bash
python3 -m venv .venv-gym-chrono
source .venv-gym-chrono/bin/activate
python3 -m pip install --upgrade pip
python3 -m pip install "gymnasium>=0.29" "numpy>=1.24,<2"

python3 gym_chrono/test/smoke_viper_walk.py
```

**Expected:** a line starting with `ok` and NumPy shapes `(18,)`.

### 4) Same host, **PyTorch ROCm** + **Ray** (CPU sim actors + GPU visible to driver)

Install a **PyTorch ROCm** build that matches your ROCm driver (see [PyTorch — Get Started](https://pytorch.org/get-started/locally/)), then:

```bash
source .venv-gym-chrono/bin/activate
python3 -m pip install "ray[default]>=2.34"
```

**Single-node Ray** (replace `N` with the number of Instinct GPUs you want Ray to advertise on this host):

```bash
# Select GPUs for the session (AMD Instinct — use ROCR, not CUDA_VISIBLE_DEVICES)
export ROCR_VISIBLE_DEVICES="${ROCR_VISIBLE_DEVICES:-0}"

# Ray + PyTorch ROCm: set before any `import ray` in your driver process
export RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES="${RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES:-1}"
export RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES="${RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES:-1}"

ray stop --force 2>/dev/null || true
ray start --head --num-gpus="${NUM_GPUS:-1}" --disable-usage-stats
```

**Driver script** — checked in as **`playground/reviewer_ray_chrono_smoke.py`**. Inline copy for convenience:

```python
#!/usr/bin/env python3
"""Minimal Ray + ChronoViperWalk on AMD: CPU actors, GPU left for torch (optional)."""
from __future__ import annotations

import os

os.environ.setdefault("RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES", "1")
os.environ.setdefault("RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES", "1")

import numpy as np
import ray

_CHRONO_CPU = {
    "env_vars": {
        "HIP_VISIBLE_DEVICES": "-1",
        "ROCR_VISIBLE_DEVICES": "-1",
    }
}


@ray.remote(num_cpus=1, runtime_env=_CHRONO_CPU)
class ViperActor:
    def __init__(self, seed: int) -> None:
        import gymnasium as gym

        import gym_chrono  # noqa: F401 — registration

        self._env = gym.make("ChronoViperWalk-v0", render_mode=None)
        self._env.reset(seed=seed)

    def step(self) -> float:
        a = self._env.action_space.sample()
        _obs, r, _term, _trunc, _info = self._env.step(a)
        return float(r)


def main() -> None:
    if not os.environ.get("CHRONO_DATA_DIR"):
        raise SystemExit("Set CHRONO_DATA_DIR to your Chrono data directory.")
    ray.init()
    actors = [ViperActor.remote(i) for i in range(2)]
    rewards = ray.get([a.step.remote() for a in actors])
    print("rewards", rewards)
    ray.shutdown()


if __name__ == "__main__":
    main()
```

```bash
chmod +x playground/reviewer_ray_chrono_smoke.py
python3 playground/reviewer_ray_chrono_smoke.py
```

**Optional:** in the same venv, `python3 -c "import torch; print(torch.cuda.is_available(), torch.version.hip)"` should report HIP-enabled PyTorch on a ROCm box. Keep **heavy** GPU work out of the Ray actors that construct `ChronoViperWalk-v0` unless you intentionally port kernels.

### 5) Tear down

```bash
ray stop --force
```
